### PR TITLE
feat: fixed setLuneContext not compiling correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rbxts/tether",
-  "version": "1.3.24",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rbxts/tether",
-      "version": "1.3.24",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@flamework/core": "^1.3.2",

--- a/src/emitters/server-emitter.ts
+++ b/src/emitters/server-emitter.ts
@@ -4,7 +4,8 @@ import { Error } from "../logging";
 import { ContextualEmitter } from "./contextual-emitter";
 import type { BaseMessage, ServerMessageCallback, ServerFunctionMessageCallback } from "../structs";
 
-declare function setLuneContext(ctx: "server" | "client" | "both"): void;
+declare let setLuneContext: (ctx: "server" | "client" | "both") => void;
+setLuneContext ??= () => { };
 
 export class ServerEmitter<MessageData> extends ContextualEmitter<MessageData> {
   public readonly context = "server";


### PR DESCRIPTION
for some reason declare function wasnt working properly so i switched this file to define setlLuneContext like message-emitter does, and it fixes the error, bassically server-emitter would error when running a remote function since it sets the lune context there and it was an unknown global